### PR TITLE
fix: skip today's events if their aren't any (fix #25, fix #17)

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,9 +26,10 @@ function groupStreams(streams) {
                 offset = '0';
             }
         }
+
         // Stream is tomorrow.
         if (isTomorrow(new Date(startTime))) {
-            if (offset === '0') {
+            if (!offset || offset === '0') {
                 insertHeading(stream, 'Tomorrow’s Livestreams');
                 offset = '1';
             }


### PR DESCRIPTION
If there are no events left on the current day, start with "Tomorrow's Livestreams" (fixes #17 and fixes #25).